### PR TITLE
Properly read empty string token in POSIX mode

### DIFF
--- a/shlex_test.go
+++ b/shlex_test.go
@@ -122,6 +122,11 @@ var datanonposix = []struct {
 		[]string{`"'Strip extra layer of quotes'"`},
 		nil,
 	},
+	{
+		`two "" blanks ''`,
+		[]string{"two", "\"\"", "blanks", "''"},
+		nil,
+	},
 }
 
 var dataposix = []struct {
@@ -235,6 +240,11 @@ var dataposix = []struct {
 	},
 	{`"'Strip extra layer of quotes'"`,
 		[]string{`'Strip extra layer of quotes'`},
+		nil,
+	},
+	{
+		`two "" blanks ''`,
+		[]string{"two", "", "blanks", ""},
 		nil,
 	},
 }


### PR DESCRIPTION
In POSIX mode, empty string tokens are currently ignored from analysed strings. This PR fixes this particular issue.

Given that `desertbit/go-shlex` `Split` function is used to split the command line into args by `desertbit/grumble`, empty string arguments are currently ignored.

Currently, ```shlex.Split(`two "" blanks ''`, true)``` gives ```[]string{"two", "blanks"}```, after the fix it gives ```[]string{"two", "", "blanks", ""}```